### PR TITLE
Feature/pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: c
+
+addons:
+    apt:
+        packages:
+            # 32 bit support
+            - gcc-multilib
+
+os:
+    - linux
+    - osx
+
+# test gcc and clang
+compiler:
+    - gcc
+    - clang
+
+env:
+    - host_cpu=ia32
+    - host_cpu=x86-64
+
+script:
+    - git clone https://github.com/intelxed/mbuild.git
+    - mkdir build
+    - cd build && ../mfile.py host_cpu=$host_cpu test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ env:
     - host_cpu=x86-64
 
 script:
-    - git clone https://github.com/intelxed/mbuild.git
+    - pip install https://github.com/intelxed/mbuild/zipball/master
     - mkdir build
     - cd build && ../mfile.py host_cpu=$host_cpu test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ env:
     - host_cpu=x86-64
 
 script:
-    - pip install https://github.com/intelxed/mbuild/zipball/master
+    - pip install --user https://github.com/intelxed/mbuild/zipball/master
     - mkdir build
     - cd build && ../mfile.py host_cpu=$host_cpu test

--- a/scripts/elf_sizes.py
+++ b/scripts/elf_sizes.py
@@ -22,8 +22,11 @@ import os
 import sys
 import subprocess
 import find_dir
-sys.path.append(find_dir.find_dir('mbuild'))
-import mbuild
+try:
+    import mbuild
+except:
+    sys.path.append(find_dir.find_dir('mbuild'))
+    import mbuild
 
 def _warn(s):
     sys.stderr.write("ERROR:" + s + "\n")

--- a/scripts/perftest.py
+++ b/scripts/perftest.py
@@ -25,8 +25,11 @@ import textwrap
 import find_dir
 import math
 
-sys.path.append(find_dir.find_dir('mbuild'))
-import mbuild
+try:
+    import mbuild
+except:    
+    sys.path.append(find_dir.find_dir('mbuild'))
+    import mbuild
 
 def graph_it(lst):
     import numpy as np


### PR DESCRIPTION
Do not merge this!

It would be more pythonic to pip install mbuild, from a local directory or directly from github as is done in this PR.

Other parts of the build look for the directory, so it does not work. Maybe too big a change:

[STATUS] RUNNING: 0    PENDING: 0    COMPLETED: 47   ERRORS: 0   ELAPSED: 927 msecs 
[COMMAND     ] gcc      -m32   -o obj/examples/xed-ex-agen obj/examples/xed-ex-agen.o obj/examples/xed-examples-util.o obj/examples/xed-dot.o obj/examples/xed-dot-prep.o obj/examples/xed-enc-lang.o obj/libxed.a  
[EXAMPLES BUILD ELAPSED TIME] 1 secs
[STRIPPING] /home/travis/build/rscohn2/xed/build/obj/examples/xed-min
[XED-MIN SIZE] 3465276 = 3.30MB
Could not find /mbuild file, looking upwards
The command "cd build && ../mfile.py host_cpu=$host_cpu test" exited with 1.
Done. Your build exited with 1.