### PR TITLE
specify travis-ci configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ matrix:
     - compiler: clang
       os: osx
       env: host_cpu=ia32 shared_static=--shared
-    - compiler: clang
-      os: osx
-      env: host_cpu=ia32 shared_static=--static
+    #- compiler: clang
+    #  os: osx
+    #  env: host_cpu=ia32 shared_static=--static
     - compiler: clang
       os: osx
       env: host_cpu=x86-64 shared_static=--shared
-    - compiler: clang
-      os: osx
-      env: host_cpu=x86-64 shared_static=--static
+    #- compiler: clang
+    #  os: osx
+    #  env: host_cpu=x86-64 shared_static=--static
      
 script:
     - pip install --user https://github.com/intelxed/mbuild/zipball/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,34 @@ addons:
             # 32 bit support
             - gcc-multilib
 
-os:
-    - linux
-    - osx
-
-# test gcc and clang
-compiler:
-    - gcc
-    - clang
-
-env:
-    - host_cpu=ia32
-    - host_cpu=x86-64
-
+matrix:
+    include:
+    - compiler: gcc
+      os: linux
+      env: host_cpu=ia32 shared_static=--shared
+    - compiler: gcc
+      os: linux
+      env: host_cpu=ia32 shared_static=--static
+    - compiler: gcc
+      os: linux
+      env: host_cpu=x86-64 shared_static=--shared
+    - compiler: gcc
+      os: linux
+      env: host_cpu=x86-64 shared_static=--static
+    - compiler: clang
+      os: osx
+      env: host_cpu=ia32 shared_static=--shared
+    - compiler: clang
+      os: osx
+      env: host_cpu=ia32 shared_static=--static
+    - compiler: clang
+      os: osx
+      env: host_cpu=x86-64 shared_static=--shared
+    - compiler: clang
+      os: osx
+      env: host_cpu=x86-64 shared_static=--static
+     
 script:
     - pip install --user https://github.com/intelxed/mbuild/zipball/master
     - mkdir build
-    - cd build && ../mfile.py host_cpu=$host_cpu test
+    - cd build && ../mfile.py host_cpu=$host_cpu $shared_static test


### PR DESCRIPTION
Everything but KNC

From Mark:

In an ideal world i’d say: 

{gcc (linux),msvs(windows),clang(os x)} x {32,64} x {static,dynamic)

and probably one linux gcc KNC build 64b {static, dynamic} eventually.
