### PR TITLE
Move ci logic to ci.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,30 +10,9 @@ matrix:
     include:
     - compiler: gcc
       os: linux
-      env: host_cpu=ia32 shared_static=--shared
-    - compiler: gcc
-      os: linux
-      env: host_cpu=ia32 shared_static=--static
-    - compiler: gcc
-      os: linux
-      env: host_cpu=x86-64 shared_static=--shared
-    - compiler: gcc
-      os: linux
-      env: host_cpu=x86-64 shared_static=--static
     - compiler: clang
       os: osx
-      env: host_cpu=ia32 shared_static=--shared
-    #- compiler: clang
-    #  os: osx
-    #  env: host_cpu=ia32 shared_static=--static
-    - compiler: clang
-      os: osx
-      env: host_cpu=x86-64 shared_static=--shared
-    #- compiler: clang
-    #  os: osx
-    #  env: host_cpu=x86-64 shared_static=--static
      
 script:
     - pip install --user https://github.com/intelxed/mbuild/zipball/master
-    - mkdir build
-    - cd build && ../mfile.py host_cpu=$host_cpu $shared_static test
+    - python ci.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,5 @@
-environment:
-    matrix:
-        - host_cpu: ia32
-        - host_cpu: x86-64
-
 build: off
 
 test_script:
     - pip install --user https://github.com/intelxed/mbuild/zipball/master
-    - mkdir static-build
-    - cd static-build
-    - python ../mfile.py test host_cpu=%host_cpu% --static
-    - cd ..
-    - mkdir shared-build
-    - cd shared-build
-    - python ../mfile.py test host_cpu=%host_cpu% --shared
+    - python ci.py

--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,9 @@
+import os
+import platform
+import subprocess
+
+for size in ['ia32','x86-64']:
+    for link in ['','--shared']:
+        cmd = 'python mfile.py --build-dir=build host_cpu=%s %s test' % (size,link)
+        print(cmd)
+        subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
Easier to maintain. We lose parallelism, but it was not helping much
because setup time was longer than build time.