### PR TITLE
sort input files when generating prep-inputs so hash does not change

### DIFF
--- a/xed_mbuild.py
+++ b/xed_mbuild.py
@@ -176,6 +176,7 @@ class generator_inputs_t(object):
         fnames = []
         for flist in self.files.itervalues():
             fnames.extend(flist)
+        fnames.sort()
         return fnames
     
     def set_intermediate_dir(self, build_dir):


### PR DESCRIPTION
resolves #28 