### PR TITLE
Minor corrections in the documentation

### DIFF
--- a/docsrc/xed-build.txt
+++ b/docsrc/xed-build.txt
@@ -29,7 +29,7 @@ by Mark Charney
 @section INTRO Introduction
 
 XED can build with many compilers:
-  - GNU Gcc
+  - GNU GCC
   - Microsoft Visual Studio
   - Intel ICL/ICC
   - LLVM/Clang 

--- a/docsrc/xed-doc-top.txt
+++ b/docsrc/xed-doc-top.txt
@@ -44,7 +44,7 @@ Intel XED was designed to be very fast and extensible.
 
 Intel XED compiles with the following compilers:
     <ul>   
-    <li> GNU Gcc
+    <li> GNU GCC
     <li> Microsoft Visual Studio
     <li> Intel ICL/ICC
     <li> LLVM/Clang 

--- a/docsrc/xed-doc-top.txt
+++ b/docsrc/xed-doc-top.txt
@@ -151,8 +151,8 @@ Optional:
 @section TERMS Terminology
 
 
-X86 instructions are 1-15 byte values. They consist of several well
-defined components:
+X86 instructions are 1-15 byte values. They consist of several
+well-defined components:
     <ul>
     <li> Prefix bytes. 
          <ul>
@@ -214,7 +214,7 @@ The legacy prefix bytes are used for:
 There are 11 distinct legacy prefixes. Three of them (operand size,
 and the two repeat prefixes) have different meanings in different
 contexts; Sometimes they are used for opcode refinement and do not
-have their default meaning. Less frequently. two of the segment
+have their default meaning. Less frequently, two of the segment
 overrides can be used for conditional branch hints.
 
 There are also multiple ways to encode certain instructions, with the
@@ -315,7 +315,7 @@ sequences from the Intel&reg; 64 and IA-32 Architectures Software Developers Man
 
 The instruction 0x90 is very special in the instruction set because it
 gets special treatment in 64b mode. In 64b mode, 32b register writes
-normally zero the upper 32 bits of a 64b register. No so for 0x90. If
+normally zero the upper 32 bits of a 64b register. Not so for 0x90. If
 it did zero the upper 32 bits, it would not be a NOP.
 
 There are two important NOP categories. XED_CATEGORY_NOP and


### PR DESCRIPTION
Changes:
```
[1]
well defined -> well-defined
Less frequently. two of the segment... -> Less frequently, two of the segment
No so for 0x90 -> Not so for 0x90

[2]
GNU Gcc -> GNU GCC
```

Also, leaving [this link](https://github.com/intelxed/intelxed.github.io/pull/3) here for completeness.