### PR TITLE
Change AAM+AAD operand semantic type to UIMM8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ matrix:
       os: osx
       
 before_install:
-    - if [ `uname -s` = 'Linux' ]; then sudo apt-get install -y python python3 ; fi
+    - if [ `uname -s` = 'Linux' ]; then sudo apt-get install -y python python3 python3-pip ; fi
 script:
     - python ci.py

--- a/datafiles/xed-isa.txt
+++ b/datafiles/xed-isa.txt
@@ -8029,7 +8029,7 @@ CATEGORY  : DECIMAL
 EXTENSION : BASE
 ISA_SET   : I86
 FLAGS     : MUST [ of-u sf-mod zf-mod af-u pf-mod cf-u ]
-PATTERN   : 0xD4 not64 SIMM8()
+PATTERN   : 0xD4 not64 UIMM8()
 OPERANDS  : IMM0:r:b:i8 REG0=XED_REG_AL:rw:SUPP REG1=XED_REG_AH:w:SUPP
 }
 {
@@ -8039,7 +8039,7 @@ CATEGORY  : DECIMAL
 EXTENSION : BASE
 ISA_SET   : I86
 FLAGS     : MUST [ of-u sf-mod zf-mod af-u pf-mod cf-u ]
-PATTERN   : 0xD5 not64 SIMM8()
+PATTERN   : 0xD5 not64 UIMM8()
 OPERANDS  : IMM0:r:b:i8 REG0=XED_REG_AL:rw:SUPP REG1=XED_REG_AH:rw:SUPP
 }
 {


### PR DESCRIPTION
XED currently disassembles `d4 cc` to `aam 0xFFFFFFCC` because the operand has the wrong signedness definition.