### PR TITLE
xed-iform-map.h: XED_INLINE goes before the return type

### DIFF
--- a/include/public/xed/xed-iform-map.h
+++ b/include/public/xed/xed-iform-map.h
@@ -71,7 +71,7 @@ xed_uint32_t xed_iform_first_per_iclass(xed_iclass_enum_t iclass);
 /// function returns valid data as soon as global data is initialized. (This
 /// function does not require a decoded instruction as input).
 static
-xed_iclass_enum_t XED_INLINE xed_iform_to_iclass(xed_iform_enum_t iform) {
+XED_INLINE xed_iclass_enum_t xed_iform_to_iclass(xed_iform_enum_t iform) {
     const xed_iform_info_t* ii = xed_iform_map(iform);
     if (ii)
         return (xed_iclass_enum_t) ii->iclass;


### PR DESCRIPTION
Change-Id: Ie1bae0b97e70589af1b7768f7efcf1fd5cd5dc59