### PR TITLE
regexp fix for python 3.7. Replace '[[]' with '\['

### DIFF
--- a/xed_mbuild.py
+++ b/xed_mbuild.py
@@ -2182,7 +2182,7 @@ def _run_canned_tests(env,osenv):
 
     for l in stdout:
         l = l.rstrip()
-        if re.search(r'^[[](TESTS|ERRORS|SKIPPED|PASS_PCT|FAIL)[]]',l):
+        if re.search(r'^\[(TESTS|ERRORS|SKIPPED|PASS_PCT|FAIL)\]',l):
            mbuild.msgb("TESTSUMMARY", l)
     if retcode == 0:
         mbuild.msgb("CANNED TESTS", "PASSED")


### PR DESCRIPTION
  * python3.7.0 added FutureWarning for regexps that will conflict with a
    future upgrade to python regexp to support unicode nested sets.

    https://docs.python.org/3/whatsnew/3.7.html

Change-Id: I8d135d0dde463fb407ddfa1de3a76219b376680b
(cherry picked from commit 01333f95ea34eac82617b06695a7cfd0408e731d)