### PR TITLE
Fix README.md command formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ https://github.com/intelxed/xed/issues/new
 
 ## Abbreviated building instructions:
 
-    git clone https://github.com/intelxed/xed.git xed
-    git clone https://github.com/intelxed/mbuild.git mbuild
-    cd xed
-    ./mfile.py
+```shell
+git clone https://github.com/intelxed/xed.git xed
+git clone https://github.com/intelxed/mbuild.git mbuild
+cd xed
+./mfile.py
+```
 
 then get your libxed.a from the obj directory.
 Add " --shared" if you want a shared object build.
@@ -33,17 +35,21 @@ There are two options:
 
 1) When building libxed you can also build the examples, from the main directory (above examples):
 
-    ./mfile.py examples
+```shell
+./mfile.py examples
+```
 
 and the compiled examples will be in obj/examples.
     
 2) Build a compiled "kit" and the build the examples from within the kit:
 
-    ./mfile.py install
-    cd kits
-    cd <whatever the kit is called>
-    cd examples
-    ./mfile.py
+```shell
+./mfile.py install
+cd kits
+cd <whatever the kit is called>
+cd examples
+./mfile.py
+```
     
 
 See source build documentation for more information.


### PR DESCRIPTION
The "cd <whatever the kit is called>" in the abbreviated build
instructions is not shown correctly by github.com.

This patch changes the Markdown formatting for shell commands to
make github's parser happy.