### PR TITLE
use const pointer for xed3_operand_get_nprefixes

### DIFF
--- a/include/public/xed/xed-decoded-inst-api.h
+++ b/include/public/xed/xed-decoded-inst-api.h
@@ -129,7 +129,7 @@ xed_decoded_inst_vector_length_bits(xed_decoded_inst_t const* const p);
 /// @ingroup DEC
 /// Returns the number of legacy prefixes.
 XED_DLL_EXPORT xed_uint_t
-xed_decoded_inst_get_nprefixes(xed_decoded_inst_t* p);
+xed_decoded_inst_get_nprefixes(const xed_decoded_inst_t* p);
 
 //@}
 

--- a/src/dec/xed-decoded-inst.c
+++ b/src/dec/xed-decoded-inst.c
@@ -874,7 +874,7 @@ xed_decoded_inst_masked_vector_operation(xed_decoded_inst_t* p)
 
 
 xed_uint_t
-xed_decoded_inst_get_nprefixes(xed_decoded_inst_t* p) {
+xed_decoded_inst_get_nprefixes(const xed_decoded_inst_t* p) {
     return xed3_operand_get_nprefixes(p);
 }
 


### PR DESCRIPTION
Hello all,

The function `xed_decoded_inst_get_nprefixes`

https://github.com/intelxed/xed/blob/c8c6c148b9381f02a5d88d469888e3a57bd9e9ea/include/public/xed/xed-decoded-inst-api.h#L131-L132

does not change its argument, so the parameter `xed_decoded_inst_t* p` should be `const`.