### PR TITLE
Improve error message when parsing hex bytes

### DIFF
--- a/examples/xed-ex4.c
+++ b/examples/xed-ex4.c
@@ -86,12 +86,16 @@ main(int argc, char** argv)
     xed_decoded_inst_set_mode(&xedd, mmode, stack_addr_width);
 
     for(  ;i < argc; i++)    {
+        if (strlen(argv[i]) != 2) {
+            fprintf(stderr, "not two hex characters: \"%s\"\n", argv[i]);
+            exit(1);
+        }
         xed_uint8_t x = (xed_uint8_t)(xed_atoi_hex(argv[i]));
         assert(bytes < XED_MAX_INSTRUCTION_BYTES);
         itext[bytes++] = x;
     }
     if (bytes == 0)    {
-        fprintf(stderr, "Must supply some hex bytes\n");
+        fprintf(stderr, "Must supply some hex bytes, e.g., 48 89 C0\n");
         exit(1);
     }
 

--- a/examples/xed-ex6.c
+++ b/examples/xed-ex6.c
@@ -80,12 +80,16 @@ main(int argc, char** argv) {
     xed_decoded_inst_set_mode(&xedd, mmode, stack_addr_width);
 
     for( i=first_argv ;i < argc; i++)    {
+        if (strlen(argv[i]) != 2) {
+            fprintf(stderr, "not two hex characters: \"%s\"\n", argv[i]);
+            exit(1);
+        }
         xed_uint8_t x = (xed_uint8_t)(xed_atoi_hex(argv[i]));
         assert(bytes < XED_MAX_INSTRUCTION_BYTES);
         itext[bytes++] = x;
     }
     if (bytes == 0)    {
-        fprintf(stderr, "Must supply some hex bytes\n");
+        fprintf(stderr, "Must supply some hex bytes, e.g., 48 89 C0\n");
         exit(1);
     }
 

--- a/examples/xed-ex7.c
+++ b/examples/xed-ex7.c
@@ -90,12 +90,16 @@ main(int argc, char** argv) {
     xed_decoded_inst_set_mode(&xedd, mmode, stack_addr_width);
 
     for( i=first_argv ;i < argc; i++)    {
+        if (strlen(argv[i]) != 2) {
+            fprintf(stderr, "not two hex characters: \"%s\"\n", argv[i]);
+            exit(1);
+        }
         xed_uint8_t x = (xed_uint8_t)(xed_atoi_hex(argv[i]));
         assert(bytes < XED_MAX_INSTRUCTION_BYTES);
         itext[bytes++] = x;
     }
     if (bytes == 0)    {
-        fprintf(stderr, "Must supply some hex bytes\n");
+        fprintf(stderr, "Must supply some hex bytes, e.g., 48 89 C0\n");
         exit(1);
     }
 

--- a/examples/xed-ex8.c
+++ b/examples/xed-ex8.c
@@ -95,12 +95,16 @@ main(int argc, char** argv) {
     xed_decoded_inst_set_mode(&xedd, mmode, stack_addr_width);
 
     for( i=first_argv ;i < argc; i++)    {
+        if (strlen(argv[i]) != 2) {
+            fprintf(stderr, "not two hex characters: \"%s\"\n", argv[i]);
+            exit(1);
+        }
         xed_uint8_t x = (xed_uint8_t)(xed_atoi_hex(argv[i]));
         assert(bytes < XED_MAX_INSTRUCTION_BYTES);
         itext[bytes++] = x;
     }
     if (bytes == 0)    {
-        fprintf(stderr, "Must supply some hex bytes\n");
+        fprintf(stderr, "Must supply some hex bytes, e.g., 48 89 C0\n");
         exit(1);
     }
 


### PR DESCRIPTION
Previously the examples yielded a confusing error message:

```
$ obj/examples/xed-ex6 -64 4889C0
PARSING BYTES: c0
Not enough bytes provided
```