### PR TITLE
Fix 64-bit Windows builds.

### DIFF
--- a/examples/xed-disas-pecoff.cpp
+++ b/examples/xed-disas-pecoff.cpp
@@ -181,7 +181,7 @@ public:
             disabled_redirection = true;
 #endif
 
-    file_handle_ = CreateFile(input_file_name,
+    file_handle_ = CreateFileA(input_file_name,
                               GENERIC_READ,
                               FILE_SHARE_READ,
                               NULL,

--- a/examples/xed-enc-lang.c
+++ b/examples/xed-enc-lang.c
@@ -299,11 +299,11 @@ static void mem_bis_parser_init(mem_bis_parser_t* self, char* s)
             unsigned64_disp = convert_ascii_hex_to_int(self->disp);
             self->disp_width_bits = nibbles*4; // nibbles to bits
             switch (self->disp_width_bits){
-              case 8:  self->disp_val = xed_sign_extend8_64(unsigned64_disp);
+              case 8:  self->disp_val = xed_sign_extend8_64((xed_int8_t)unsigned64_disp);
                 break;
-              case 16: self->disp_val = xed_sign_extend16_64(unsigned64_disp);
+              case 16: self->disp_val = xed_sign_extend16_64((xed_int16_t)unsigned64_disp);
                 break;
-              case 32: self->disp_val = xed_sign_extend32_64(unsigned64_disp);
+              case 32: self->disp_val = xed_sign_extend32_64((xed_int32_t)unsigned64_disp);
                 break;
               case 64: self->disp_val = unsigned64_disp;
                 break;
@@ -567,7 +567,7 @@ parse_encode_request(ascii_encode_request_t areq)
         if (imm2.valid) {
             if (imm2.width_bits != 8)
                 xedex_derror("2nd immediate must be just 1 byte long");
-            xed_encoder_request_set_uimm1(&req, imm2.immed_val);
+            xed_encoder_request_set_uimm1(&req, (xed_uint8_t)imm2.immed_val);
             xed_encoder_request_set_operand_order(&req,
                                                   operand_index,
                                                   XED_OPERAND_IMM1);

--- a/examples/xed-examples-util.c
+++ b/examples/xed-examples-util.c
@@ -70,7 +70,7 @@ update_histogram(xed_stats_t* p,
 {
     xed_uint32_t bin;
     if (delta  < XED_HISTO_MAX_CYCLES)
-        bin = delta / XED_HISTO_CYCLES_PER_BIN;
+        bin = (xed_uint32_t)(delta / XED_HISTO_CYCLES_PER_BIN);
     else
         bin = XED_HISTO_BINS-1;
     p->histo[bin]++;
@@ -1179,7 +1179,7 @@ void xed_disas_test(xed_disas_info_t* di)
 
         /* if we get near the end of the section, clip the itext length */
         ilim = 15;
-        elim = di->q - z;
+        elim = (int)(di->q - z);
         if (elim < ilim) 
            ilim = elim;
 

--- a/examples/xed.c
+++ b/examples/xed.c
@@ -666,7 +666,7 @@ main(int argc, char** argv)
         else if (strcmp(argv[i],"-set")==0) {
             test_argc(i+1,argc); // need 2 args
             operand = str2xed_operand_enum_t(argv[i+1]);
-            operand_value = xed_atoi_general(argv[i+2],1000);
+            operand_value = (xed_uint32_t)xed_atoi_general(argv[i+2],1000);
             i += 2;
         }
 #if 0


### PR DESCRIPTION
Suppress assorted type conversion warnings; call CreateFileA even in 64-bit builds.