### PR TITLE
Fix weird file comparison mismatches happening on Windows

### DIFF
--- a/tests/run-cmd.py
+++ b/tests/run-cmd.py
@@ -51,10 +51,11 @@ import mbuild
 
 def write_file(fn,lines):
     print("[EMIT] %s" % (fn))
-    f = open(fn,"w")
+    # write the file in binary mode to prevent LF -> CR LF expansion on Windows
+    f = open(fn,"wb")
     if lines:
         for line in lines:
-            f.write(line)
+            f.write(line.replace('\r', '')) # gobble CR symbols if any
     f.close()
 
 
@@ -143,6 +144,7 @@ def _prep_stream(strm,name):
         strm.pop()
     for line in strm:
         print("[{}] {} {}".format(name,len(line),line))
+    return strm
 
 def one_test(env,test_dir):
 
@@ -158,11 +160,9 @@ def one_test(env,test_dir):
     (retcode, stdout,stderr) = mbuild.run_command(cmd2,separate_stderr=True)
     print("Retcode %s" % (str(retcode)))
     if stdout:
-        _prep_stream(stdout,"STDOUT")
+        stdout = _prep_stream(stdout,"STDOUT")
     if stderr:
-        _prep_stream(stderr,"STDERR")
-
-
+        stderr = _prep_stream(stderr,"STDERR")
 
     ret_match = compare_file(os.path.join(test_dir,"retcode.reference"), [ str(retcode) ])
     stdout_match = compare_file(os.path.join(test_dir,"stdout.reference"), stdout)


### PR DESCRIPTION
Two issues were addressed.
1. Emitting of reference files is now done in binary mode to prevent Python
   from expanding EOL symbols into pairs of CR LF.

2. _prep_stream() operated on a copy of input argument, and changes it did
   had no effects outside the function. It now returns the modified value back.