### PR TITLE
Add "-Wformat" to fix compilation with MinGW GCC

### DIFF
--- a/xed_build_common.py
+++ b/xed_build_common.py
@@ -218,6 +218,7 @@ def set_env_gnu(env):
     
     flags += ' -Wall'
     flags += ' -Wformat-security'
+    flags += ' -Wformat'
     # the windows compiler finds this stuff so flag it on other platforms
     flags += ' -Wunused' 
     


### PR DESCRIPTION
The compiler we use to build Xed on Windows hosts identifies itself as:
    C:\Users\grechist>c:\mingw64\bin\gcc --version
    gcc (x86_64-posix-seh-rev1, Built by MinGW-W64 project) 4.9.2

As it is now, the compilation fails with:

    cc1.exe: error: -Wformat-security ignored without -Wformat [-Werror=format-security]

Adding `-Wformat` in addition to `-Wformat-security` should be relatively safe as there are no formatting issues in Xed.