### PR TITLE
Allow for Mach-O disassembly on non-macOS platforms.

### DIFF
--- a/examples/mach-o.h
+++ b/examples/mach-o.h
@@ -1,0 +1,172 @@
+/*BEGIN_LEGAL
+
+Copyright (c) 2020 Intel Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+END_LEGAL */
+/// @file mach-o.h
+#if !defined(XED_MACHO_H)
+# define XED_MACHO_H
+
+#include <stdint.h>
+
+// Mach-O structs and constants for non-macOS builds
+
+typedef int	cpu_type_t;
+typedef int	cpu_subtype_t;
+typedef int	vm_prot_t;
+
+#define FAT_CIGAM 0xbebafeca
+
+struct fat_header {
+	uint32_t	magic;		/* FAT_MAGIC */
+	uint32_t	nfat_arch;  /* number of structs that follow */
+};
+
+#define CPU_TYPE_I386 ((cpu_type_t)7)
+#define CPU_ARCH_ABI64 0x01000000
+
+struct fat_arch {
+	cpu_type_t	cputype;	/* cpu specifier (int) */
+	cpu_subtype_t	cpusubtype;	/* machine specifier (int) */
+	uint32_t	offset;		/* file offset to this object file */
+	uint32_t	size;		/* size of this object file */
+	uint32_t	align;		/* alignment as a power of 2 */
+};
+
+#define MH_MAGIC 0xfeedface
+#define MH_MAGIC_64 0xfeedfacf
+
+struct mach_header {
+	uint32_t	magic;		/* mach magic number identifier */
+	cpu_type_t	cputype;	/* cpu specifier */
+	cpu_subtype_t	cpusubtype;	/* machine specifier */
+	uint32_t	filetype;	/* type of file */
+	uint32_t	ncmds;		/* number of load commands */
+	uint32_t	sizeofcmds;	/* the size of all the load commands */
+	uint32_t	flags;		/* flags */
+};
+struct mach_header_64 {
+	uint32_t	magic;		/* mach magic number identifier */
+	cpu_type_t	cputype;	/* cpu specifier */
+	cpu_subtype_t	cpusubtype;	/* machine specifier */
+	uint32_t	filetype;	/* type of file */
+	uint32_t	ncmds;		/* number of load commands */
+	uint32_t	sizeofcmds;	/* the size of all the load commands */
+	uint32_t	flags;		/* flags */
+	uint32_t	reserved;	/* reserved */
+};
+
+#define	LC_SEGMENT 0x1
+#define	LC_SYMTAB 0x2
+#define	LC_SEGMENT_64 0x19
+
+struct segment_command { /* for 32-bit architectures */
+	uint32_t	cmd;		/* LC_SEGMENT */
+	uint32_t	cmdsize;	/* includes sizeof section structs */
+	char		segname[16];	/* segment name */
+	uint32_t	vmaddr;		/* memory address of this segment */
+	uint32_t	vmsize;		/* memory size of this segment */
+	uint32_t	fileoff;	/* file offset of this segment */
+	uint32_t	filesize;	/* amount to map from the file */
+	vm_prot_t	maxprot;	/* maximum VM protection */
+	vm_prot_t	initprot;	/* initial VM protection */
+	uint32_t	nsects;		/* number of sections in segment */
+	uint32_t	flags;		/* flags */
+};
+struct segment_command_64 { /* for 64-bit architectures */
+	uint32_t	cmd;		/* LC_SEGMENT_64 */
+	uint32_t	cmdsize;	/* includes sizeof section_64 structs */
+	char		segname[16];	/* segment name */
+	uint64_t	vmaddr;		/* memory address of this segment */
+	uint64_t	vmsize;		/* memory size of this segment */
+	uint64_t	fileoff;	/* file offset of this segment */
+	uint64_t	filesize;	/* amount to map from the file */
+	vm_prot_t	maxprot;	/* maximum VM protection */
+	vm_prot_t	initprot;	/* initial VM protection */
+	uint32_t	nsects;		/* number of sections in segment */
+	uint32_t	flags;		/* flags */
+};
+
+#define S_ATTR_SOME_INSTRUCTIONS 0x00000400
+#define S_ATTR_PURE_INSTRUCTIONS 0x80000000
+
+struct section { /* for 32-bit architectures */
+	char		sectname[16];	/* name of this section */
+	char		segname[16];	/* segment this section goes in */
+	uint32_t	addr;		/* memory address of this section */
+	uint32_t	size;		/* size in bytes of this section */
+	uint32_t	offset;		/* file offset of this section */
+	uint32_t	align;		/* section alignment (power of 2) */
+	uint32_t	reloff;		/* file offset of relocation entries */
+	uint32_t	nreloc;		/* number of relocation entries */
+	uint32_t	flags;		/* flags (section type and attributes)*/
+	uint32_t	reserved1;	/* reserved (for offset or index) */
+	uint32_t	reserved2;	/* reserved (for count or sizeof) */
+};
+struct section_64 { /* for 64-bit architectures */
+	char		sectname[16];	/* name of this section */
+	char		segname[16];	/* segment this section goes in */
+	uint64_t	addr;		/* memory address of this section */
+	uint64_t	size;		/* size in bytes of this section */
+	uint32_t	offset;		/* file offset of this section */
+	uint32_t	align;		/* section alignment (power of 2) */
+	uint32_t	reloff;		/* file offset of relocation entries */
+	uint32_t	nreloc;		/* number of relocation entries */
+	uint32_t	flags;		/* flags (section type and attributes)*/
+	uint32_t	reserved1;	/* reserved (for offset or index) */
+	uint32_t	reserved2;	/* reserved (for count or sizeof) */
+	uint32_t	reserved3;	/* reserved */
+};
+
+struct load_command {
+	uint32_t cmd;		/* type of load command */
+	uint32_t cmdsize;	/* total size of command in bytes */
+};
+
+struct symtab_command {
+	uint32_t	cmd;		/* LC_SYMTAB */
+	uint32_t	cmdsize;	/* sizeof(struct symtab_command) */
+	uint32_t	symoff;		/* symbol table offset */
+	uint32_t	nsyms;		/* number of symbol table entries */
+	uint32_t	stroff;		/* string table offset */
+	uint32_t	strsize;	/* string table size in bytes */
+};
+
+#define N_STAB 0xe0
+#define N_PEXT 0x10
+#define N_TYPE 0x0e
+#define N_EXT 0x01
+#define N_SECT 0xe
+
+struct nlist {
+	union {
+		uint32_t n_strx;	/* index into the string table */
+	} n_un;
+	uint8_t n_type;		/* type flag, see below */
+	uint8_t n_sect;		/* section number or NO_SECT */
+	int16_t n_desc;		/* see <mach-o/stab.h> */
+	uint32_t n_value;	/* value of this symbol (or stab offset) */
+};
+struct nlist_64 {
+	union {
+		uint32_t n_strx;	/* index into the string table */
+	} n_un;
+	uint8_t n_type;        /* type flag, see below */
+	uint8_t n_sect;        /* section number or NO_SECT */
+	uint16_t n_desc;       /* see <mach-o/stab.h> */
+	uint64_t n_value;      /* value of this symbol (or stab offset) */
+};
+
+#endif

--- a/examples/xed-disas-macho.c
+++ b/examples/xed-disas-macho.c
@@ -18,13 +18,17 @@ END_LEGAL */
 /// @file xed-disas-macho.cpp
 
 #include "xed/xed-interface.h" // to get defines
-#if defined(__APPLE__) && defined(XED_DECODER)
+#if defined(XED_DECODER)
 
 // mac specific headers
+#ifdef __APPLE__
 #include <mach-o/fat.h>
 #include <mach-o/loader.h>
 #include <mach-o/stab.h>
 #include <mach-o/nlist.h>
+#else
+#include "mach-o.h"
+#endif
 
 #include "xed-disas-macho.h"
 #include "xed-examples-util.h"

--- a/examples/xed-disas-macho.h
+++ b/examples/xed-disas-macho.h
@@ -19,11 +19,9 @@ END_LEGAL */
 #if !defined(XED_DISAS_MACHO_H)
 # define XED_DISAS_MACHO_H
 
-# if defined(__APPLE__)
 #  include "xed/xed-interface.h" 
 #  include "xed-examples-util.h" 
 
 void
 xed_disas_macho(xed_disas_info_t* fi);
-# endif
 #endif

--- a/examples/xed.c
+++ b/examples/xed.c
@@ -212,13 +212,12 @@ static void usage(char* prog) {
     unsigned int i;
     static const char* usage_msg[] = {
       "One of the following is required:",
-#if defined(__APPLE__)
-      "\t-i input_file             (decode macho-format file)",
-#elif defined(XED_ELF_READER)
+#if defined(XED_ELF_READER)
       "\t-i input_file             (decode elf-format file)",
 #elif defined(_WIN32)
       "\t-i input_file             (decode pecoff-format file)",
 #endif
+      "\t-macho input_file         (decode macho-format file)",
       "\t-ir raw_input_file        (decode a raw unformatted binary file)",
       "\t-ih hex_input_file        (decode a raw unformatted ASCII hex file)",
       "\t-d hex-string             (decode a sequence of bytes, must be last)",
@@ -384,6 +383,7 @@ main(int argc, char** argv)
     xed_bool_t decode_encode = 0;
     int i,j;
     unsigned int loop_decode = 0;
+    xed_bool_t disas_macho = 0;
     xed_bool_t decode_raw = 0;
     xed_bool_t decode_hex = 0;
     xed_bool_t assemble  = 0;
@@ -481,6 +481,12 @@ main(int argc, char** argv)
         else if (strcmp(argv[i],"-i")==0)        {
             test_argc(i,argc);
             input_file_name = argv[i+1];
+            i++;
+        }
+        else if (strcmp(argv[i],"-macho")==0)        {
+            test_argc(i,argc);
+            input_file_name = argv[i+1];
+            disas_macho = 1;
             i++;
         }
 #if defined(XED_USING_DEBUG_HELP)
@@ -882,7 +888,11 @@ main(int argc, char** argv)
             printf("<XEDDISASM>\n");
             printf("<XEDFORMAT>1</XEDFORMAT>\n");
         }
-        if (decode_raw) {
+        /* Disassemble using specified format. */
+        if (disas_macho) {
+            xed_disas_macho(&decode_info);
+        }
+        else if (decode_raw) {
             xed_disas_raw(&decode_info);
         }
         else if (decode_hex) {
@@ -890,6 +900,8 @@ main(int argc, char** argv)
         }
         else
         {
+            /* Disassemble using default format.  This will differ
+               according to target platform for the xed build. */
 #if defined(__APPLE__)
             xed_disas_macho(&decode_info);
 #elif defined(XED_ELF_READER)

--- a/examples/xed_examples_mbuild.py
+++ b/examples/xed_examples_mbuild.py
@@ -327,7 +327,8 @@ def build_examples(env, work_queue):
     xed_cmdline_files = [ 'xed-disas-raw.c',
                           'avltree.c',
                           'xed-disas-hex.c',
-                          'xed-symbol-table.c']
+                          'xed-symbol-table.c',
+                          'xed-disas-macho.c']
     if env.on_windows() and env['set_copyright']:
         # AUTOMATICALLY UPDATE YEAR IN THE RC FILE
         year = time.strftime("%Y")
@@ -344,9 +345,6 @@ def build_examples(env, work_queue):
             xed_cmdline_files.append('xed-disas-filter.c')
             xed_cmdline_files.append('xed-nm-symtab.c')
             
-        elif env.on_mac():
-            xed_cmdline_files.append('xed-disas-macho.c')
-
         elif env.on_windows():
             xed_cmdline_files.append('xed-disas-pecoff.cpp')
             if ( env['dbghelp'] and 


### PR DESCRIPTION
This allows `xed_disas_macho()` to be compiled and linked into the `xed` binary on platforms other than macOS.  It is often convenient to analyze binary objects on another operating system.  (I can try and make a similar patch for `PECOFF` binaries if there is interest.)  Thank you.