### PR TITLE
Unify description of unpack instructions

### DIFF
--- a/datafiles/xed-isa.txt
+++ b/datafiles/xed-isa.txt
@@ -8844,8 +8844,7 @@ CPL       : 3
 CATEGORY  : SSE
 EXTENSION : SSE
 EXCEPTIONS: SSE_TYPE_4
-ATTRIBUTES :  REQUIRES_ALIGNMENT
-COMMENT   : mem form only uses q portion of the dq load. See SDM.
+ATTRIBUTES : SKIPHIGH64 REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x14 no_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  MODRM()
 OPERANDS  : REG0=XMM_R():rw:ps MEM0:r:dq
 PATTERN   : 0x0F 0x14 no_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]
@@ -8957,8 +8956,7 @@ CPL       : 3
 CATEGORY  : SSE
 EXTENSION : SSE2
 EXCEPTIONS: SSE_TYPE_4
-ATTRIBUTES :  REQUIRES_ALIGNMENT
-COMMENT   : mem form only uses q portion of the dq load. See SDM.
+ATTRIBUTES : SKIPHIGH64 REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x14 osz_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  REFINING66() MODRM()
 OPERANDS  : REG0=XMM_R():rw:pd MEM0:r:dq
 PATTERN   : 0x0F 0x14 osz_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]  REFINING66()
@@ -9609,8 +9607,7 @@ CPL       : 3
 CATEGORY  : SSE
 EXTENSION : SSE2
 EXCEPTIONS: SSE_TYPE_4
-ATTRIBUTES :  REQUIRES_ALIGNMENT
-COMMENT   : mem form only uses q portion of the dq load. See SDM.
+ATTRIBUTES : SKIPHIGH64 REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x60 osz_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  REFINING66() MODRM()
 OPERANDS  : REG0=XMM_R():rw:dq MEM0:r:dq
 PATTERN   : 0x0F 0x60 osz_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]  REFINING66()
@@ -9622,8 +9619,7 @@ CPL       : 3
 CATEGORY  : SSE
 EXTENSION : SSE2
 EXCEPTIONS: SSE_TYPE_4
-ATTRIBUTES :  REQUIRES_ALIGNMENT
-COMMENT   : mem form only uses q portion of the dq load. See SDM.
+ATTRIBUTES : SKIPHIGH64 REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x61 osz_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  REFINING66() MODRM()
 OPERANDS  : REG0=XMM_R():rw:dq MEM0:r:dq
 PATTERN   : 0x0F 0x61 osz_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]  REFINING66()
@@ -9635,8 +9631,7 @@ CPL       : 3
 CATEGORY  : SSE
 EXTENSION : SSE2
 EXCEPTIONS: SSE_TYPE_4
-ATTRIBUTES :  REQUIRES_ALIGNMENT
-COMMENT   : mem form only uses q portion of the dq load. See SDM.
+ATTRIBUTES : SKIPHIGH64 REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x62 osz_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  REFINING66() MODRM()
 OPERANDS  : REG0=XMM_R():rw:dq MEM0:r:dq
 PATTERN   : 0x0F 0x62 osz_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]  REFINING66()
@@ -12422,8 +12417,7 @@ CPL       : 3
 CATEGORY  : SSE
 EXTENSION : SSE2
 EXCEPTIONS: SSE_TYPE_4
-ATTRIBUTES :  REQUIRES_ALIGNMENT
-COMMENT   : mem form only uses q portion of the dq load. See SDM.
+ATTRIBUTES : SKIPHIGH64 REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x6C osz_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  REFINING66() MODRM()
 OPERANDS  : REG0=XMM_R():rw:dq MEM0:r:dq
 PATTERN   : 0x0F 0x6C osz_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]  REFINING66()

--- a/datafiles/xed-isa.txt
+++ b/datafiles/xed-isa.txt
@@ -8861,7 +8861,7 @@ ATTRIBUTES : SKIPLOW64  REQUIRES_ALIGNMENT
 PATTERN   : 0x0F 0x15 no_refining_prefix MOD[mm] MOD!=3 REG[rrr] RM[nnn]  MODRM()
 OPERANDS  : REG0=XMM_R():rw:ps MEM0:r:dq
 PATTERN   : 0x0F 0x15 no_refining_prefix MOD[0b11] MOD=3 REG[rrr] RM[nnn]
-OPERANDS  : REG0=XMM_R():rw:ps REG1=XMM_B():r:dq
+OPERANDS  : REG0=XMM_R():rw:ps REG1=XMM_B():r:q
 }
 {
 ICLASS    : MOVHPS


### PR DESCRIPTION
* Fix operand size for UNPCKHPS
* Introduce SKIPHIGH64 similar to SKIPLOW64 used by 'high packed' unpack instructions.