### PR TITLE
Handle XED_OPERAND_AGEN in  xed_decoded_inst_get_find_memop()

### DIFF
--- a/src/dec/xed-decoded-inst.c
+++ b/src/dec/xed-decoded-inst.c
@@ -369,6 +369,7 @@ xed_decoded_inst_get_find_memop(const xed_decoded_inst_t* p,
         const xed_operand_t* o = xed_inst_operand(inst,i);
         const xed_operand_enum_t op_name = xed_operand_name(o);
         if ((memop_idx == 0 && op_name == XED_OPERAND_MEM0) ||
+            (memop_idx == 0 && op_name == XED_OPERAND_AGEN) ||
             (memop_idx == 1 && op_name == XED_OPERAND_MEM1))   {
             return i;
         }


### PR DESCRIPTION
Fix `xed_decoded_inst_get_find_memop()` to handle `XED_OPERAND_AGEN` pseudo-op used with `LEA` instructions.  `XED_OPERAND_AGEN` can appear in the same operand positions as `XED_OPERAND_MEM0`.

Without the fix, `xed-ex1` would crash thusly:
```
D:\GitHub\zlaski\xed\sdk\bin>xed-ex1 -64 4C 8D 1D 9D 40 00 00
Attempting to decode: 4c 8d 1d 9d 40 00 00
iclass LEA      category MISC   ISA-extension BASE      ISA-set I86
instruction-length 7
operand-width 64
effective-operand-width 64
effective-address-width 64
stack-address-width 64
iform-enum-name LEA_GPRv_AGEN
iform-enum-name-dispatch (zero based) 0
iclass-max-iform-dispatch 1
Nominal opcode position 1
Nominal opcode 0x8d
Operands
#   TYPE               DETAILS        VIS  RW       OC2 BITS BYTES NELEM ELEMSZ   ELEMTYPE   REGCLASS
#   ====               =======        ===  ==       === ==== ===== ===== ======   ========   ========
0   REG0              REG0=R11   EXPLICIT   W         V   64     8     1     64        INT        GPR
1   AGEN           (see below)   EXPLICIT   R    PSEUDO   64     8     1      0        INT    INVALID
Memory Operands
  0    agen BASE= RIP/ IP DISPLACEMENT_BYTES= 4 0x000000000000409d base10=16541ASSERTION FAILURE 0 at D:/GitHub/zlaski/xed/src/dec/xed-decoded-inst.c:376
```