### PR TITLE
Fix clang compile.

### DIFF
--- a/xed_build_common.py
+++ b/xed_build_common.py
@@ -289,6 +289,7 @@ def set_env_gnu(env):
 
 def set_env_clang(env):
    set_env_gnu(env)
+   env['CCFLAGS'] += ' -Wno-language-extension-token'
         
 def set_env_ms(env):
     """Set up the MSVS environment for compilation"""

--- a/xed_build_common.py
+++ b/xed_build_common.py
@@ -290,6 +290,7 @@ def set_env_gnu(env):
 def set_env_clang(env):
    set_env_gnu(env)
    env['CCFLAGS'] += ' -Wno-language-extension-token'
+   env['CXXFLAGS'] += ' -Wno-unused-function'
         
 def set_env_ms(env):
     """Set up the MSVS environment for compilation"""


### PR DESCRIPTION
`-Wno-language-extension-token` need to be added, or the there will be compile errors when using clang, at least version 13.0.0 is tested.