### PR TITLE
Prevent strange output when `git describe` fails

### DIFF
--- a/xed_mbuild.py
+++ b/xed_mbuild.py
@@ -2445,7 +2445,7 @@ def get_git_version(env):
             line = stdout[0].strip()
             return line
         else:
-            xbc.dump_lines("git version description", "FAILED")
+            xbc.dump_lines("git version description", ["FAILED"])
             xbc.dump_lines("git description stdout", stdout)
             xbc.dump_lines("git description stderr", stderr)
 


### PR DESCRIPTION
Pass a list with a single string inside.
Without wrapping it into a list, `xbc.dump_lines()` iterates over characters of a string, printing one character per line:

```
F
A
I
L
E
D
```