### PR TITLE
docsrc: Update required python version in docs

### DIFF
--- a/docsrc/xed-build.txt
+++ b/docsrc/xed-build.txt
@@ -117,7 +117,7 @@ https://intelxed.github.io (or inside Intel http://mjc.intel.com/mjcharne/mbuild
 The XED build using mbuild is dependence driven It uses file and
 command signatures to detect the need to rebuild files.
 
-The mbuild script requires python version 2.7, python 3.4 or later.
+The mbuild script requires python version 3.6 or later.
 
 
 Assuming you checked out the tree as described above, you can build

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,6 +1,6 @@
 
 
-To build the examples, a relatively recent version of python 2.7 is required.
+To build the examples, a relatively recent version of python 3.6 is required.
 
 ================================
 STATIC LIBRARY XED BUILD:
@@ -12,7 +12,7 @@ STATIC LIBRARY XED BUILD:
 
   Windows:
 
-   % C:/python27/python mfile.py
+   % C:/python36/python mfile.py
 
 ================================
 DYNAMIC  LIBRARY XED BUILD:
@@ -27,6 +27,6 @@ If you have a a shared-object (or DLL build on windows) you must also include
 
   Windows:
 
-   % C:/python27/python mfile.py --shared
+   % C:/python36/python mfile.py --shared
  
 Add "--help" (no quotes) for more build options.


### PR DESCRIPTION
After some testing, it looks like the oldest python version XED/mbuild supports is 3.6.