### PR TITLE
Update `XED_NORETURN` to support modern C standards

### DIFF
--- a/include/public/xed/xed-portability.h
+++ b/include/public/xed/xed-portability.h
@@ -158,7 +158,6 @@ XED_DLL_EXPORT int xed_strncat(char* dst, const char* src,  int len);
 #       define XED_INLINE inline
 #    endif
 # endif
-# define XED_NORETURN __attribute__ ((noreturn))
 # if __GNUC__ == 2
 #   define XED_NOINLINE 
 # else
@@ -171,6 +170,15 @@ XED_DLL_EXPORT int xed_strncat(char* dst, const char* src,  int len);
 # else
 #   define XED_NOINLINE __declspec(noinline)
 # endif
+#endif
+
+#if __STDC_VERSION__ >= 202311L
+# define XED_NORETURN [[noreturn]]
+#elif __STDC_VERSION__ >= 201112L
+# define XED_NORETURN _Noreturn
+#elif defined(__GNUC__)
+# define XED_NORETURN __attribute__ ((__noreturn__))
+#else
 # define XED_NORETURN __declspec(noreturn)
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/intelxed/xed/issues/332

The `XED_NORETURN` macro is incompatible with software using C11. Update the macro logic to use the C23 `[[noreturn]]` attribute syntax or C11 `_Noreturn` keyword respectively when the standard is in use. For compatibility with C99, the GNU extension `__attribute__((__noreturn__))` is used as a fallback, which does not cause compile warnings if `noreturn` is a macro (e.g. from `stdnoreturn.h`).