### PR TITLE
Make INVLPGB parameters suppressed instead of implicit

### DIFF
--- a/datafiles/amd/xed-amd-invlpgb.txt
+++ b/datafiles/amd/xed-amd-invlpgb.txt
@@ -13,7 +13,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 #END_LEGAL
 INSTRUCTIONS()::
 
@@ -25,13 +25,13 @@ EXTENSION : AMD_INVLPGB
 ATTRIBUTES: AMDONLY
 COMMENT   : Is this 64b mode only?
 PATTERN   : 0x0F 0x01 MOD[0b11] MOD=3 REG[0b111] RM[0b110] no_refining_prefix eamode32
-OPERANDS  : REG0=XED_REG_EAX:r:IMPL \
-            REG1=XED_REG_EDX:r:IMPL \
-            REG2=XED_REG_ECX:r:IMPL 
+OPERANDS  : REG0=XED_REG_EAX:r:SUPP \
+            REG1=XED_REG_EDX:r:SUPP \
+            REG2=XED_REG_ECX:r:SUPP
 PATTERN   : 0x0F 0x01 MOD[0b11] MOD=3 REG[0b111] RM[0b110] no_refining_prefix eamode64
-OPERANDS  : REG0=XED_REG_RAX:r:IMPL \
-            REG1=XED_REG_EDX:r:IMPL \
-            REG2=XED_REG_ECX:r:IMPL 
+OPERANDS  : REG0=XED_REG_RAX:r:SUPP \
+            REG1=XED_REG_EDX:r:SUPP \
+            REG2=XED_REG_ECX:r:SUPP
 }
 {
 ICLASS    : TLBSYNC
@@ -40,7 +40,7 @@ CATEGORY  : SYSTEM
 EXTENSION : AMD_INVLPGB
 ATTRIBUTES: AMDONLY
 PATTERN   : 0x0F 0x01 MOD[0b11] MOD=3 REG[0b111] RM[0b111] no_refining_prefix
-OPERANDS  : 
+OPERANDS  :
 }
 
 


### PR DESCRIPTION
According to AMD's manual, the parameters to INVLPGB are suppressed instead of implicit.