### PR TITLE
Clang -Wcast-function-type-mismatch warning fix

### DIFF
--- a/examples/xed-util-disas-pecoff.cpp
+++ b/examples/xed-util-disas-pecoff.cpp
@@ -84,7 +84,7 @@ typedef int (WINAPI *fptr_t)(void*);
 static fptr_t find_fn_ptr(const char* function_name)  {
    fptr_t p;
 
-   p = (fptr_t) GetProcAddress(
+   p = (fptr_t)(void *) GetProcAddress(
                    GetModuleHandle(TEXT("kernel32.dll")), 
                    function_name);
    return p;


### PR DESCRIPTION
This fixes a `-Wcast-function-type-mismatch` warning that is generated when compiling examples using Clang on Windows:

```
.../xed/wkit/examples/xed-util-disas-pecoff.cpp:87:8: error: cast from 'FARPROC' (aka 'long long (*)()') to 'fptr_t' (aka 'int (*)(void *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
   87 |    p = (fptr_t) GetProcAddress(
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
   88 |                    GetModuleHandle(TEXT("kernel32.dll")), 
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   89 |                    function_name);
      |                    ~~~~~~~~~~~~~~
1 error generated.
```

This causes a compiler error due to `-Werror` being set by default.  This commit adds a void pointer cast before casting to `fptr_t` which effectively ignores this warning.